### PR TITLE
Fixing Contract Test Failures

### DIFF
--- a/aws-iotfleethub-application/inputs/inputs_1_create.json
+++ b/aws-iotfleethub-application/inputs/inputs_1_create.json
@@ -1,5 +1,11 @@
 {
   "ApplicationName": "CfnApplicationTestName",
   "ApplicationDescription": "CfnApplicationTestDescription",
-  "RoleArn": "arn:aws:iam::{{ContractTestExecutionAccountId}}:role/AWSIotFleetHub_3"
+  "RoleArn": "arn:aws:iam::{{ContractTestExecutionAccountId}}:role/AWSIotFleetHub_3",
+  "Tags": [
+    {
+      "Key": "testTagKeyOriginal",
+      "Value": "testTagValueOriginal"
+    }
+  ]
 }

--- a/aws-iotfleethub-application/inputs/inputs_1_update.json
+++ b/aws-iotfleethub-application/inputs/inputs_1_update.json
@@ -4,8 +4,8 @@
   "RoleArn": "arn:aws:iam::{{ContractTestExecutionAccountId}}:role/AWSIotFleetHub_3",
   "Tags": [
     {
-      "Key": "testTagKey",
-      "Value": "testTagValue"
+      "Key": "testTagKeyUpdated",
+      "Value": "testTagValueUpdated"
     }
   ]
 }

--- a/aws-iotfleethub-application/pom.xml
+++ b/aws-iotfleethub-application/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>[2.0.0,3.0.0)</version>
+            <version>2.0.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-iotfleethub-application/pom.xml
+++ b/aws-iotfleethub-application/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.5</version>
+            <version>[2.0.0,3.0.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-iotfleethub-application/src/main/java/software/amazon/iotfleethub/application/CreateHandler.java
+++ b/aws-iotfleethub-application/src/main/java/software/amazon/iotfleethub/application/CreateHandler.java
@@ -42,12 +42,12 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.InvalidRequest, "ClientToken was not provided.");
         }
 
-        if (Translator.isReadOnlyFieldSet(model, logger, "ApplicationArn", model.getApplicationArn())
-                || Translator.isReadOnlyFieldSet(model, logger, "ApplicationId", model.getApplicationId())
-                || Translator.isReadOnlyFieldSet(model, logger, "ApplicationUrl", model.getApplicationUrl())
-                || Translator.isReadOnlyFieldSet(model, logger, "ApplicationState", model.getApplicationState())
-                || Translator.isReadOnlyFieldSet(model, logger, "SsoClientId", model.getSsoClientId())
-                || Translator.isReadOnlyFieldSet(model, logger, "ErrorMessage", model.getErrorMessage())) {
+        if (Translator.isReadOnlyFieldSet(logger, "ApplicationArn", model.getApplicationArn())
+                || Translator.isReadOnlyFieldSet(logger, "ApplicationId", model.getApplicationId())
+                || Translator.isReadOnlyFieldSet(logger, "ApplicationUrl", model.getApplicationUrl())
+                || Translator.isReadOnlyFieldSet(logger, "ApplicationState", model.getApplicationState())
+                || Translator.isReadOnlyFieldSet(logger, "SsoClientId", model.getSsoClientId())
+                || Translator.isReadOnlyFieldSet(logger, "ErrorMessage", model.getErrorMessage())) {
 
             return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.InvalidRequest,
                     "Can only set ApplicationName, RoleArn, ApplicationDescription (optional), and Tags (optional) in CreateApplication call.");

--- a/aws-iotfleethub-application/src/main/java/software/amazon/iotfleethub/application/Translator.java
+++ b/aws-iotfleethub-application/src/main/java/software/amazon/iotfleethub/application/Translator.java
@@ -122,13 +122,25 @@ public class Translator {
   }
 
   static boolean isReadOnlyFieldSet(
-          ResourceModel model,
           Logger logger,
           String fieldType,
           String fieldValue) {
 
     if (!StringUtils.isEmpty(fieldValue)) {
       logger.log(String.format("%s is Read-Only, but the caller passed %s.", fieldType, fieldValue));
+      return true;
+    }
+    return false;
+  }
+
+  static boolean isReadOnlyFieldChanged(
+          Logger logger,
+          String fieldType,
+          String previousFieldValue,
+          String currentFieldValue) {
+
+    if (!StringUtils.equals(previousFieldValue, currentFieldValue)) {
+      logger.log(String.format("%s is Read-Only, but the caller attempted to modify %s to %s", fieldType, previousFieldValue, currentFieldValue));
       return true;
     }
     return false;

--- a/aws-iotfleethub-application/src/main/java/software/amazon/iotfleethub/application/UpdateHandler.java
+++ b/aws-iotfleethub-application/src/main/java/software/amazon/iotfleethub/application/UpdateHandler.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 
 public class UpdateHandler extends BaseHandler<CallbackContext> {
 
@@ -38,6 +39,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
             final CallbackContext callbackContext,
             final Logger logger) {
 
+        ResourceModel prevModel = request.getPreviousResourceState();
         ResourceModel model = request.getDesiredResourceState();
 
         // UpdateHandler must return a NotFound error if the ApplicationId is not provided
@@ -51,12 +53,13 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
             return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.InvalidRequest, "ClientToken was not provided.");
         }
 
-        if (Translator.isReadOnlyFieldSet(model, logger, "ApplicationArn", model.getApplicationArn())
-                || Translator.isReadOnlyFieldSet(model, logger, "ApplicationUrl", model.getApplicationUrl())
-                || Translator.isReadOnlyFieldSet(model, logger, "ApplicationState", model.getApplicationState())
-                || Translator.isReadOnlyFieldSet(model, logger, "SsoClientId", model.getSsoClientId())
-                || Translator.isReadOnlyFieldSet(model, logger, "ErrorMessage", model.getErrorMessage())) {
-
+        if (Objects.isNull(prevModel)) {
+            logger.log(String.format("Previous Resource State not found."));
+        } else if (Translator.isReadOnlyFieldChanged(logger, "ApplicationArn", prevModel.getApplicationArn(), model.getApplicationArn())
+                || Translator.isReadOnlyFieldChanged(logger, "ApplicationUrl", prevModel.getApplicationUrl(), model.getApplicationUrl())
+                || Translator.isReadOnlyFieldChanged(logger, "ApplicationState", prevModel.getApplicationState(), model.getApplicationState())
+                || Translator.isReadOnlyFieldChanged(logger, "SsoClientId", prevModel.getSsoClientId(), model.getSsoClientId())
+                || Translator.isReadOnlyFieldChanged(logger, "ErrorMessage", prevModel.getErrorMessage(), model.getErrorMessage())) {
             return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.InvalidRequest,
                     "Can only update ApplicationName, ApplicationDescription, or Tags.");
         }

--- a/aws-iotfleethub-application/src/test/java/software/amazon/iotfleethub/application/UpdateHandlerTest.java
+++ b/aws-iotfleethub-application/src/test/java/software/amazon/iotfleethub/application/UpdateHandlerTest.java
@@ -49,6 +49,7 @@ import static software.amazon.iotfleethub.application.TestConstants.APPLICATION_
 import static software.amazon.iotfleethub.application.TestConstants.APPLICATION_DESCRIPTION;
 import static software.amazon.iotfleethub.application.TestConstants.APPLICATION_DESCRIPTION_2;
 import static software.amazon.iotfleethub.application.TestConstants.APPLICATION_ID;
+import static software.amazon.iotfleethub.application.TestConstants.APPLICATION_ID_2;
 import static software.amazon.iotfleethub.application.TestConstants.APPLICATION_LAST_UPDATE_DATE;
 import static software.amazon.iotfleethub.application.TestConstants.APPLICATION_NAME;
 import static software.amazon.iotfleethub.application.TestConstants.APPLICATION_NAME_2;
@@ -202,14 +203,21 @@ public class UpdateHandlerTest {
 
     @Test
     public void handleRequest_SettingReadOnlyFields_Failure() {
-        ResourceModel desiredModel = ResourceModel.builder()
+        ResourceModel previousModel = ResourceModel.builder()
                 .applicationId(APPLICATION_ID)
+                .applicationName(APPLICATION_NAME)
+                .applicationDescription(APPLICATION_DESCRIPTION)
+                .build();
+
+        ResourceModel desiredModel = ResourceModel.builder()
+                .applicationId(APPLICATION_ID_2)
                 .applicationArn(APPLICATION_ARN)
-                .applicationName(APPLICATION_NAME_2)
-                .applicationDescription(APPLICATION_DESCRIPTION_2)
+                .applicationName(APPLICATION_NAME)
+                .applicationDescription(APPLICATION_DESCRIPTION)
                 .build();
 
         ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .previousResourceState(previousModel)
                 .desiredResourceState(desiredModel)
                 .clientRequestToken(CLIENT_TOKEN)
                 .build();

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,7 +5,8 @@ phases:
         java: openjdk8
         python: 3.7
     commands:
-      -  pip install --upgrade 'six==1.15.0'
+      -  pip install pyyaml --upgrade
+      -  pip install --upgrade 'six~=1.15.0'
       -  pip install pre-commit cloudformation-cli-java-plugin
   build:
     commands:


### PR DESCRIPTION
Fixing recent Contract Test Failures caused by UpdateHandler. 
UpdateHandler now checks for changes to read-only fields as opposed to the mere presence of the fields. This is because the presence of these fields in the Update request is expected, as read-only fields like ApplicationId or ApplicationArn will be part of the model; as long as those fields aren't modified, the request should be valid.

buildspec.yml file has now also been updated due to Codebuild failures
